### PR TITLE
feat: support React 19

### DIFF
--- a/packages/react-inline-svg-unique-id/package.json
+++ b/packages/react-inline-svg-unique-id/package.json
@@ -29,12 +29,12 @@
     "url": "https://github.com/laleksiunas/inline-svg-unique-id/issues"
   },
   "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0"
+    "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "devDependencies": {
     "@babel/preset-react": "7.14.5",
-    "@types/react": "^17.0.24",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "@types/react": "^19.0.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
   }
 }

--- a/packages/react-inline-svg-unique-id/src/index.d.ts
+++ b/packages/react-inline-svg-unique-id/src/index.d.ts
@@ -1,5 +1,5 @@
 declare module '@inline-svg-unique-id/react' {
-  import type { FC } from 'react';
+  import type { FC, PropsWithChildren } from 'react';
 
   export interface ProviderProps {
     idPrefix?: string;
@@ -7,5 +7,5 @@ declare module '@inline-svg-unique-id/react' {
 
   export function useUniqueInlineId(): string;
 
-  export const Provider: FC<ProviderProps>;
+  export const Provider: FC<PropsWithChildren<ProviderProps>>;
 }


### PR DESCRIPTION
- Widen `peerDependencies.react` to `^17.0.0 || ^18.0.0 || ^19.0.0`
- Bump devDependencies (`react`, `react-dom`, `@types/react`) to v19
- Type `Provider` as `FC<PropsWithChildren<ProviderProps>>` so `<Provider>...</Provider>` type-checks under `@types/react` 18+

No runtime changes.

Closes #8.
